### PR TITLE
[22] Fork and exec deauth program

### DIFF
--- a/pam/Makefile
+++ b/pam/Makefile
@@ -14,6 +14,8 @@ LIB_DEP = $(SRC)/pam_bt_misc.h $(SRC)/pam_bt_pair.h $(SRC)/pam_bt_misc.h $(SRC)/
 
 all: pam_proxy.so pam_test
 
+pam: pam_proxy.so
+
 pam_proxy.so: pam_proxy.o $(LIB_DEP)
 	sudo ld $(LDFLAGS) -o $(LINUX_PAM_PATH)$@ $< $(BLUETOOTH_LIB) $(LDLIBS) $(GLIB)
 	rm $<
@@ -28,4 +30,4 @@ install:
 	perl install.pl
 
 clean:
-	rm -f *.o $(PAM_PATH)
+	rm -f *.o $(PAM_PATH) pam_test

--- a/pam/src/pam_post_auth.h
+++ b/pam/src/pam_post_auth.h
@@ -1,0 +1,45 @@
+#ifndef PAM_POST_AUTH
+#define PAM_POST_AUTH
+
+#define DEAUTH "deauth"
+
+/*
+* Once Authenticated, run the deauth background service
+*
+* NOTE: exec replaces the child process. Memory mappings are not preservered on an exec() call so memory is reclaimed apparently.
+*/
+int exec_deauth() {
+    int pid = fork();
+
+    if (pid == 0) { //child process
+        char *path = NULL;
+    
+        char **argv = {NULL};
+
+        int len = strlen(trusted_dir_path) + strlen(DEAUTH);
+
+        if (!(path = malloc(sizeof(char) + len + 1))) {
+            perror("malloc");
+            return PAM_BUF_ERR;
+        }
+
+        if (!(strncpy(path, trusted_dir_path, strlen(trusted_dir_path)))) {
+            perror("strncpy");
+            return PAM_BUF_ERR;
+        }
+
+        path[strlen(trusted_dir_path)] = '\0';
+
+        if (!(strncat(path, DEAUTH, strlen(DEAUTH) + 1))) {
+            perror("strncat");
+            return PAM_BUF_ERR;
+        }
+        
+        path[len] = '\0';
+
+        execv(path, argv);
+
+    }
+    return PAM_SUCCESS;	
+}
+#endif

--- a/pam/src/pam_proxy.c
+++ b/pam/src/pam_proxy.c
@@ -26,7 +26,7 @@
 #include "pam_bt_misc.h"
 #include "pam_bt_pair.h"
 #include "pam_bt_trust.h"
-
+#include "pam_post_auth.h"
 
 PAM_EXTERN int pam_sm_setcred( pam_handle_t *pamh, int flags, int argc, const char **argv ) {
 	return PAM_SUCCESS;
@@ -35,6 +35,7 @@ PAM_EXTERN int pam_sm_setcred( pam_handle_t *pamh, int flags, int argc, const ch
 PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv) {
 	return PAM_SUCCESS;
 }
+
 
 PAM_EXTERN int pam_sm_authenticate( pam_handle_t *pamh, int flags,int argc, const char **argv ) {
 	int bluetooth_status = PAM_AUTH_ERR;
@@ -63,7 +64,7 @@ PAM_EXTERN int pam_sm_authenticate( pam_handle_t *pamh, int flags,int argc, cons
 	   if (log_fp) {
             fprintf(log_fp, "Login via Auth Proxy\n");
         }
-       bluetooth_status = PAM_SUCCESS;
+        bluetooth_status = PAM_SUCCESS;
     }
 
 pam_sm_authenticate:

--- a/pam/src/pam_test.c
+++ b/pam/src/pam_test.c
@@ -26,6 +26,7 @@
 #include "pam_bt_misc.h"
 #include "pam_bt_pair.h"
 #include "pam_bt_trust.h"
+#include "pam_post_auth.h"
 
 int main(int argc, char **argv)
 {
@@ -42,6 +43,7 @@ int main(int argc, char **argv)
     printf("start bluetooth_login\n");
     if (bluetooth_login(log_fp, trusted_dir_path, username)) {
        printf("Welcome %s. Login via Auth Proxy.\n", username);
+       exec_deauth();
     }
     else {
         printf("Failed");


### PR DESCRIPTION
Tested on `pam_test` and also the PAM itself. Works as intended. Once logging in, the deauth program will be executed. After the phone connects with the deauth program, the server will expect a response and if it does not get a response, the deauth program will lock the computer and terminate.