### PR TITLE
Android: Switch back to main activity if connection to server does not exist

### DIFF
--- a/android/app/src/main/java/com/example/myapplicationtest/ControlActivity.kt
+++ b/android/app/src/main/java/com/example/myapplicationtest/ControlActivity.kt
@@ -11,6 +11,7 @@ import android.os.AsyncTask
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat.startActivity
 import kotlinx.android.synthetic.main.control_layout.*
 import org.jetbrains.anko.toast
 import java.io.IOException
@@ -137,17 +138,19 @@ class ControlActivity: AppCompatActivity(){
                 connectSuccess =  false
 
                 Log.d("data", "FAILED TO CONNECT\n")
-
                 e.printStackTrace()
 
             }
             return null
         }
 
-        override  fun onPostExecute(result: String?){
+        override fun onPostExecute(result: String?){
             super.onPostExecute(result)
             if(!connectSuccess){
                 Log.i("data", "Couldn't CONNECT")
+                val intent = Intent(this.context, MainActivity::class.java)
+                this.context.toast("Failed to connect to " + m_address)
+                this.context.startActivity(intent)
             } else {
                 Log.i("data", "CONNECTED")
                 m_isConnected = true


### PR DESCRIPTION
This pull request addresses the following issues:
* #19  
* #21

tldr: I ensured to switch back to main activity with a notification when the user disconnects from the server or when the app fails to connect to the server. 