### PR TITLE
Bluetooth Sanitization

### DIFF
--- a/pam/src/pam_bt_misc.h
+++ b/pam/src/pam_bt_misc.h
@@ -1,5 +1,5 @@
-#ifndef PAM_BT_MISC
-#define PAM_BT_MISC
+#ifndef PAM_BT_MISC_H
+#define PAM_BT_MISC_H
 
 #define BT_MAC_LEN 17
 #define BT_MAX_CONN 7 //Bluetooth Adapters can only connect up to 7 devices
@@ -34,10 +34,16 @@ int verify_bt_addr(char *address, FILE *log_fp) {
 
     if (strlen(address) <= BT_MAC_LEN) {   
         while (curr && len < strlen(address)) {
-            if((isxdigit(*curr) == 0 &&  (len + 1) % 3 != 0 && *curr != ':' ) || len > BT_MAC_LEN) {
+            int is_div3 = (len + 1) % 3 == 0;
+            
+            if (    len > BT_MAC_LEN ||                                 //exceeds the BT String Len
+                    (isxdigit(*curr) == 0 && !is_div3) ||               //not Alphanumeric when it should be
+                    (isxdigit(*curr) == 0 && is_div3 && *curr != ':')   //not a colon when it should be
+                ) {
                 is_valid = 0;
                 break;
             }
+
             len++;
             curr++;
         }


### PR DESCRIPTION
## Issue: #13 

Tested and resolved a bug with sanitizing bluetooth address.
There was no strict checking whether every 3rd character was a ':' or any other special character. 

**Failed Test Case:** '77;02:28:23:54:A4' 
Failed to detect the 3rd character is `;` and not a `:`

## Test Cases
```
/* VALID BT ADDRESSES ***/    
    char *bt = "11:22:33:44:55:66";
    if (!verify_bt_addr(bt, log_fp)) {
        printf("%s is a valid address\n", bt);
    }

    bt = "77:02:28:23:54:A4";
    if (!verify_bt_addr(bt, log_fp)) {
        printf("%s is a valid address\n", bt);
    }

    bt = "F0:81:73:92:2E:C2";
    if (!verify_bt_addr(bt, log_fp)) {
        printf("%s is a valid address\n", bt);
    }
    /**********************/

    /* INVALID ADDRESS ***/
    bt = "77:02:28:23:54:__";
    if (verify_bt_addr(bt, log_fp)) {
        printf("%s is NOT a valid address\n", bt);
    }
    bt = "77:02:28:23:54:";
    if (verify_bt_addr(bt, log_fp)) {
        printf("%s is NOT a valid address\n", bt);
    }
    bt = "";
    if (verify_bt_addr(bt, log_fp)) {
        printf("%s is NOT a valid address\n", bt);
    }
    bt = "!!:!!:!!:!!:!!:!!";
    if (verify_bt_addr(bt, log_fp)) {
        printf("%s is NOT a valid address\n", bt);
    }

    bt = "77:02:28:23:54:!4";
    if (verify_bt_addr(bt, log_fp)) {
        printf("%s is NOT a valid address\n", bt);
    }

    bt = "770228235434";
    if (verify_bt_addr(bt, log_fp)) {
        printf("%s is NOT a valid address\n", bt);
    }

    bt = "77;02:28:23:54:A4";
    if (verify_bt_addr(bt, log_fp)) {
        printf("%s is NOT a valid address\n", bt);
    }

    bt = "77:02:2*:23:54:A4";
    if (verify_bt_addr(bt, log_fp)) {
        printf("%s is NOT a valid address\n", bt);
    }
    /*********************/
```