### PR TITLE
Kim deauth

### DIFF
--- a/pam/Makefile
+++ b/pam/Makefile
@@ -11,8 +11,6 @@ BLUETOOTH_LIB = -lbluetooth
 LDLIBS = -lc
 SRC = src
 LIB_DEP = $(SRC)/pam_bt_misc.h $(SRC)/pam_bt_pair.h $(SRC)/pam_bt_misc.h $(SRC)/pam_bt_trust.h
-# LD_PRELOAD=${LIB_ASAN_PATH} $(PAM_PATH)
-#gcc -print-file-name=libasan.so
 
 all: pam_proxy.so pam_test deauth
 
@@ -37,4 +35,4 @@ install:
 	perl install.pl
 
 clean:
-	rm -f *.o $(PAM_PATH) pam_test
+	rm -f *.o $(PAM_PATH) pam_test $(DEAUTH_PATH)deauth

--- a/pam/src/deauth.c
+++ b/pam/src/deauth.c
@@ -20,6 +20,7 @@
 #include "pam_bt_misc.h"
 #include "pam_bt_pair.h"
 #include "pam_bt_trust.h"
+#include "proxy_dbus.h"
 
 
 #define SERVICE_NAME "Proxy Auth"
@@ -35,6 +36,18 @@ sdp_session_t *sdp_connect( const bdaddr_t *src, const bdaddr_t *dst, uint32_t f
 int sdp_close( sdp_session_t *session );
 
 int sdp_record_register(sdp_session_t *sess, sdp_record_t *rec, uint8_t flags);
+
+void terminate_server(int client, int server, sdp_session_t *session) {
+    if (client) {
+        close(client);
+    }
+    if (server) {
+        close(server);
+    }
+    if (session) {
+        sdp_close(session);
+    }
+}
 
 /*
 * Set the general service ID and service class
@@ -301,7 +314,7 @@ void lock() {
 int main (int argc, char **argv)
 {
     struct sockaddr_rc loc_addr = { 0 }, rem_addr = { 0 };
-    int s = -1, client = -1, bytes_read;
+    int server = -1, client = -1, bytes_read;
     socklen_t opt = sizeof(rem_addr);
     sdp_session_t *session = NULL; //SDP socket
 
@@ -312,14 +325,16 @@ int main (int argc, char **argv)
         goto cleanup;
     }
 
-    s = init_server(&loc_addr, &session);
+    server = init_server(&loc_addr, &session);
     time_t start, stop;
     int is_locked = 0; 
     client = -1;
 
+    listen_lock_status(server, &client, session);
+
     while(1) {
         if (client < 0) {
-            client = connect_client(s, &rem_addr, &opt);
+            client = connect_client(server, &rem_addr, &opt);
             start = time(NULL);
             is_locked = 0; 
         }
@@ -355,8 +370,8 @@ cleanup:
     if (client) {
         close(client);
     }
-    if (s) {
-        close(s);
+    if (server) {
+        close(server);
     }
     if (session) {
         sdp_close(session);

--- a/pam/src/pam_bt_pair.h
+++ b/pam/src/pam_bt_pair.h
@@ -5,6 +5,11 @@
 #include <glib.h>
 #include <gio/gio.h>
 
+#define BLUEZ_DBUS_NAME                 "org.bluez"
+#define BLUEZ_DBUS_OBJ_PATH             "/"
+#define DBUS_INTERFACE_NAME             "org.freedesktop.DBus.ObjectManager"
+#define DBUS_METHOD_NAME                "GetManagedObjects"
+#define DBUS_METHOD_RETURN_TYPE         "(a{oa{sa{sv}}})"
 
 /*
 * Return Bluetooth address if the device is paired. Else return NULL
@@ -123,19 +128,19 @@ char **get_paired_devices(int *num_of_paired) {
         g_print("Not able to get connection to system bus\n");
         return NULL;
     }
-
+    printf("pika test\n");
     result = g_dbus_connection_call_sync(
-        conn,                                   //connection
-        "org.bluez",                            //bus_name
-        "/",                                    //object_path
-        "org.freedesktop.DBus.ObjectManager",   //interface_name
-        "GetManagedObjects",                    //method_name
-        NULL,                                   //parameters
-        G_VARIANT_TYPE("(a{oa{sa{sv}}})"),      //return type
-        G_DBUS_CALL_FLAGS_NONE,                 //flag
-        1000,                                   //timeout_msec
-        NULL,                                   //cancel error
-        NULL                                    //error if parameter is not compatible with D-Bus protocol
+        conn,                                       //connection
+        BLUEZ_DBUS_NAME,                            //bus_name
+        BLUEZ_DBUS_OBJ_PATH,                        //object_path
+        DBUS_INTERFACE_NAME,                        //interface_name
+        DBUS_METHOD_NAME,                           //method_name
+        NULL,                                       //parameters
+        G_VARIANT_TYPE(DBUS_METHOD_RETURN_TYPE),    //return type
+        G_DBUS_CALL_FLAGS_NONE,                     //flag
+        1000,                                       //timeout_msec
+        NULL,                                       //cancel error
+        NULL                                        //error if parameter is not compatible with D-Bus protocol
     );
 
     paired_devices = process_dbus_bt_list(result, num_of_paired);

--- a/pam/src/proxy_dbus.h
+++ b/pam/src/proxy_dbus.h
@@ -1,0 +1,105 @@
+#include <stdio.h>
+#include <glib.h>
+#include <gio/gio.h>
+
+#define GNOME_SESSION_DBUS_NAME                 "org.gnome.SessionManager"
+#define GNOME_SESSION_DBUS_OBJ_PATH_PRESENCE    "/org/gnome/SessionManager/Presence"
+#define GNOME_SESSION_DBUS_INTERFACE_PRESENCE   "org.gnome.SessionManager.Presence"
+
+struct dbus_obj {
+    GMainLoop *loop;
+    GDBusProxy *proxy;
+    gulong handler_id;
+    int server;
+    int *client;
+    sdp_session_t *session;
+};
+
+//Referenced https://gitlab.gnome.org/GNOME/glib/-/blob/master/gio/tests/gdbus-example-watch-proxy.c
+
+static void on_signal (
+                        GDBusProxy *proxy, 
+                        gchar *sender_name, 
+                        gchar *signal_name, 
+                        GVariant *parameters,
+                        gpointer user_data
+                    ); 
+
+void terminate_server(int client, int server, sdp_session_t *session);
+
+void terminate(struct dbus_obj *data_obj) {
+    if (data_obj->proxy) {
+        printf("test 2\n");
+        if (data_obj->handler_id > 0) {
+            g_signal_handler_disconnect(data_obj->proxy, data_obj->handler_id);
+        }
+        printf("test 3\n");
+        g_object_unref(data_obj->proxy);
+    }
+
+    if (data_obj->loop) {
+        g_main_loop_unref(data_obj->loop);
+    }
+
+    terminate_server(data_obj->server, *(data_obj->client), data_obj->session);
+
+
+    exit(0);
+}
+
+/*
+* Terminate program if user is locked by actively "listening"/monitoring the changes in presence status
+*
+* Signal Handler whenever the property of status changes
+*
+* @param proxy:
+* @param sender_name:
+* @param signal_name:
+* @param parameters:
+* @param user_data: a pointer to data that needs to be freed before terminating the program
+*/
+static void on_signal (
+                        GDBusProxy *proxy, 
+                        gchar *sender_name, 
+                        gchar *signal_name, 
+                        GVariant *parameters, //in the form of (u)
+                        gpointer user_data
+                    ) 
+{    
+    GVariant *value;
+    guint32 num = -1;
+    if ((value = g_variant_get_child_value(parameters, 0))) { //extract the value from the tuple
+        num = g_variant_get_uint32(value);
+        g_print("signal: %d\n", num);
+        terminate(user_data);
+    }
+}
+
+void listen_lock_status(int server, int *client, sdp_session_t *session) {
+    struct dbus_obj data_obj = {NULL, NULL, 0, server, client, session};
+
+    GError *error = NULL;
+
+    data_obj.loop = g_main_loop_new(NULL, FALSE);
+
+    data_obj.proxy = g_dbus_proxy_new_for_bus_sync(
+        G_BUS_TYPE_SESSION,                     //GBus Type
+        G_DBUS_PROXY_FLAGS_NONE,                //Flag to use for constructing proxy
+        NULL,                                   //GDBusInterfaceInfo
+        GNOME_SESSION_DBUS_NAME,                //Bus Name
+        GNOME_SESSION_DBUS_OBJ_PATH_PRESENCE,   //Object Path
+        GNOME_SESSION_DBUS_INTERFACE_PRESENCE,  //DBus Interface
+        NULL,                                   //GCancellable
+        &error                                  //Error struct
+    );
+
+    if (data_obj.proxy == NULL && error) {
+        g_printerr ("Error creating proxy: %s\n", error->message);
+        g_error_free (error);
+        terminate(&data_obj);
+    }
+
+    data_obj.handler_id = g_signal_connect(data_obj.proxy, "g-signal", G_CALLBACK(on_signal), &data_obj);
+    
+    g_main_loop_run(data_obj.loop);
+}


### PR DESCRIPTION
This pull requests pertains to issue #32 

The current implementation does not have `deauth` to be terminated if the user chooses to lock themselves out manually. This can cause issues where there are multiple `deauth` instances running for the same user because there will be multiple bluetooth servers advertising the same uuid.

The issue can cause errors where there is an infinite loop:
```
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
accepted connection from 00:00:00:00:00:00
```

## Changes
To resolve this issue, I have made `deauth` to continually listen to the changes in the Presence status property. I made it lock whenever there's a change in the property (although the appropriate method is to check if the signal changed to a **3** which indicates the user idle (i.e. in the lock screen).

## Test
```
$ ps -u zaku | grep deauth 
14638 ?        00:00:00 deauth                                                                                
```

The current `deauth` has a pid of `14638`. If I manually lock the computer, the instance should terminate. When I log back on, PAM should execute a new `deauth` instance with a different pid.

```
zaku@zaku-laptop:~/Documents/csc490/proxyAuth/pam$ ps -u zaku | grep deauth 
14702 ?        00:00:00 deauth                     
```
After locking, and logging back in, I can see that the previous instance of `deauth` with the pid `14638` is terminated and a new instance of `deauth` with a different pid, `14702` is spawned.

**[SUCCESS]**
