### PR TITLE
[#29] Accept Connection from Authorized Devices Only

### DIFF
--- a/pam/src/deauth.c
+++ b/pam/src/deauth.c
@@ -27,6 +27,12 @@
 #define SERVICE_DESC "Continuous Authentication via Bluetooth"
 #define SERVICE_PROV "ProxyAuth"
 
+struct server_data_t {
+    int server;
+    int *client;
+    sdp_session_t *session;
+};
+
 /*
 * Special Thanks to: Ryan Scott for providing how to register service and Albert Huang
 */
@@ -37,7 +43,7 @@ int sdp_close( sdp_session_t *session );
 
 int sdp_record_register(sdp_session_t *sess, sdp_record_t *rec, uint8_t flags);
 
-void terminate_server(int client, int server, sdp_session_t *session) {
+void terminate_server(int server, int client, sdp_session_t *session) {
     if (client) {
         close(client);
     }
@@ -227,37 +233,26 @@ int init_server(struct sockaddr_rc *loc_addr, sdp_session_t **session) {
 }
 
 /*
-* Connect a new client
+* Lock the computer, cleanup memory and open fd, and terminate program
 *
-* @param s: server's socket
-* @param rem_addr: a pointer to sockaddr structure that will store the address of the client socket
-* @param opt: the size of rem_addr
-* @return: The client's socket
+* @param server_data: a struct that contains fd that needs to be closed
 */
-int connect_client(int s, struct sockaddr_rc *rem_addr, socklen_t *opt) {
-    // accept one connection
-    char buf[1024] = { 0 };
-
-    int client = accept(s, (struct sockaddr *)rem_addr, opt);
-    fcntl(client, F_SETFL, O_NONBLOCK); //set FD to nonblocking 
-
-    //bdaddr_t stores information about the bluetooth device address.
-    ba2str(&(rem_addr->rc_bdaddr), buf); //converts the bluetooth data structure to string
-    fprintf(stderr, "accepted connection from %s\n", buf);
-
-    return client;
+void lock(struct server_data_t *server_data) {
+    system("dbus-send --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock");
+    if (server_data) {
+        terminate_server(server_data->server, *(server_data->client), server_data->session);
+        exit(0);
+    }
 }
 
 /*
-* Return 1 iff the given bluetooth address is valid
+* Return 1 iff the given bluetooth address in the argument is valid
 *
 * @param argc: number of arguments (always >= 1 due to program name stored in argv[0])
 * @param argv: array that contains cmdline arguments
-* @return: True iff the cmd argument is a valid bluetooth device
+* @return: True iff the cmd argument is a valid bluetooth address
 */
-int is_trusted_client(int argc, char **argv, const char *trusted_dir_path) {
-    int status = 0;
-
+int check_arg(int argc, char **argv) {
     if (argc <= 1) {
         fprintf(stderr, "usage: %s bt_addr\n", argv[0]);
         return 0;
@@ -267,6 +262,17 @@ int is_trusted_client(int argc, char **argv, const char *trusted_dir_path) {
         fprintf(stderr, "%s: %s is not a valid bluetooth address\n", argv[0], argv[1]);
         return 0;
     }
+    return 1;
+}
+
+/*
+* Return 1 iff the given bluetooth address is trusted and paired
+*
+* @param bt_addr: the address of the bluetooth to check
+* @return: True iff given bluetooth address is a trusted and pired device
+*/
+int is_trusted_client(char *bt_addr, const char *trusted_dir_path) {
+    int status = 0;
 
     int num_of_paired, num_of_devices;
     char *username = getlogin();
@@ -281,12 +287,12 @@ int is_trusted_client(int argc, char **argv, const char *trusted_dir_path) {
     }
 
     //check if device is paired
-    if (!(is_dev_trusted(NULL, argv[1], paired_devices, num_of_paired))) {
+    if (!(is_dev_trusted(NULL, bt_addr, paired_devices, num_of_paired))) {
         goto is_trusted_terminate;
     }
 
     //check if device is in trusted list
-    if (!is_dev_trusted(NULL, argv[1], trusted_devices, num_of_devices)) {
+    if (!is_dev_trusted(NULL, bt_addr, trusted_devices, num_of_devices)) {
         goto is_trusted_terminate;
     }
 
@@ -305,10 +311,33 @@ is_trusted_terminate:
 }
 
 /*
-* Lock the computer
+* Connect a new client. If client is not from a trusted device nor authorized then lock the system.
+*
+* @param s: server's socket
+* @param rem_addr: a pointer to sockaddr structure that will store the address of the client socket
+* @param opt: the size of rem_addr
+* @param authorized_dev: the address of the trusted device
+* @param server_data: a struct that contains fd that needs to be closed before termination
+* @return: The client's socket
 */
-void lock() {
-    system("dbus-send --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock");
+int connect_client(int s, struct sockaddr_rc *rem_addr, socklen_t *opt, char *authorized_dev, struct server_data_t *server_data) {
+    // accept one connection
+    char buf[1024] = { 0 };
+    printf("connection attempt");
+    int client = accept(s, (struct sockaddr *)rem_addr, opt);
+    fcntl(client, F_SETFL, O_NONBLOCK); //set FD to nonblocking 
+
+    //bdaddr_t stores information about the bluetooth device address.
+    ba2str(&(rem_addr->rc_bdaddr), buf); //converts the bluetooth data structure to string
+
+    fprintf(stderr, "accepted connection from %s\n", buf);
+
+    if (!is_trusted_client(buf, trusted_dir_path) || strcmp(buf, authorized_dev) != 0) {
+        printf("test lock\n");
+        lock(server_data);
+    }
+
+    return client;
 }
 
 int main (int argc, char **argv)
@@ -318,23 +347,27 @@ int main (int argc, char **argv)
     socklen_t opt = sizeof(rem_addr);
     sdp_session_t *session = NULL; //SDP socket
 
+    if (!check_arg(argc, argv)) {
+        lock(NULL);
+    }
     //check if the device passed is trusted
-    if (!is_trusted_client(argc, argv, trusted_dir_path)) {
-        printf("test lock\n");
-        lock();
-        goto cleanup;
+    if (!is_trusted_client(argv[1], trusted_dir_path)) {
+        lock(NULL);
     }
 
     server = init_server(&loc_addr, &session);
+
+    struct server_data_t server_data = {server, &client, session};
+
+
     time_t start, stop;
     int is_locked = 0; 
-    client = -1;
 
     listen_lock_status(server, &client, session);
 
     while(1) {
         if (client < 0) {
-            client = connect_client(server, &rem_addr, &opt);
+            client = connect_client(server, &rem_addr, &opt, argv[1], &server_data);
             start = time(NULL);
             is_locked = 0; 
         }
@@ -353,10 +386,8 @@ int main (int argc, char **argv)
         stop = time(NULL);  
         if ((stop - start) > 10 && !is_locked){
             //exec no response being read lock user out
-            is_locked = 1; 
-            close(client);
-            client = -1;
-            lock();
+            is_locked = 1;
+            lock(&server_data);
             break;
         }
     	
@@ -365,16 +396,5 @@ int main (int argc, char **argv)
     	}
     }
 
-cleanup:
-    // close connection
-    if (client) {
-        close(client);
-    }
-    if (server) {
-        close(server);
-    }
-    if (session) {
-        sdp_close(session);
-    }
     return 0;
 }

--- a/pam/src/deauth.c
+++ b/pam/src/deauth.c
@@ -277,8 +277,6 @@ int is_trusted_client(char *bt_addr, const char *trusted_dir_path) {
     int num_of_paired, num_of_devices;
     char *username = getlogin();
 
-    printf("User: %s\n", username);
-
     char **paired_devices = get_paired_devices(&num_of_paired);
     char **trusted_devices;
 
@@ -323,7 +321,6 @@ is_trusted_terminate:
 int connect_client(int s, struct sockaddr_rc *rem_addr, socklen_t *opt, char *authorized_dev, struct server_data_t *server_data) {
     // accept one connection
     char buf[1024] = { 0 };
-    printf("connection attempt");
     int client = accept(s, (struct sockaddr *)rem_addr, opt);
     fcntl(client, F_SETFL, O_NONBLOCK); //set FD to nonblocking 
 
@@ -333,7 +330,7 @@ int connect_client(int s, struct sockaddr_rc *rem_addr, socklen_t *opt, char *au
     fprintf(stderr, "accepted connection from %s\n", buf);
 
     if (!is_trusted_client(buf, trusted_dir_path) || strcmp(buf, authorized_dev) != 0) {
-        printf("test lock\n");
+        printf("%s is not trusted or not authorized to deauthenticate the system\n", buf);
         lock(server_data);
     }
 
@@ -359,11 +356,11 @@ int main (int argc, char **argv)
 
     struct server_data_t server_data = {server, &client, session};
 
-
     time_t start, stop;
     int is_locked = 0; 
 
-    listen_lock_status(server, &client, session);
+    //listen_lock_status(server, &client, session);
+    client = -1;
 
     while(1) {
         if (client < 0) {

--- a/pam/src/pam_bt_pair.h
+++ b/pam/src/pam_bt_pair.h
@@ -128,7 +128,7 @@ char **get_paired_devices(int *num_of_paired) {
         g_print("Not able to get connection to system bus\n");
         return NULL;
     }
-    printf("pika test\n");
+    
     result = g_dbus_connection_call_sync(
         conn,                                       //connection
         BLUEZ_DBUS_NAME,                            //bus_name

--- a/pam/src/pam_test.c
+++ b/pam/src/pam_test.c
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,6 +33,7 @@ int main(int argc, char **argv)
 {
     const char *trusted_dir_path = "/etc/proxy_auth/";
     const char *username = "zaku";
+    char *detected_dev;
 
     FILE *log_fp = NULL;
     
@@ -41,9 +43,9 @@ int main(int argc, char **argv)
     }
     /*********************/
     printf("start bluetooth_login\n");
-    if (bluetooth_login(log_fp, trusted_dir_path, username)) {
+    if (bluetooth_login(log_fp, trusted_dir_path, username, &detected_dev)) {
        printf("Welcome %s. Login via Auth Proxy.\n", username);
-       exec_deauth();
+       exec_deauth(detected_dev, username, log_fp);
     }
     else {
         printf("Failed");

--- a/pam/src/proxy_dbus.h
+++ b/pam/src/proxy_dbus.h
@@ -25,7 +25,7 @@ static void on_signal (
                         gpointer user_data
                     ); 
 
-void terminate_server(int client, int server, sdp_session_t *session);
+void terminate_server(int server, int client, sdp_session_t *session);
 
 void terminate(struct dbus_obj *data_obj) {
     if (data_obj->proxy) {

--- a/pam/src/proxy_dbus.h
+++ b/pam/src/proxy_dbus.h
@@ -80,7 +80,7 @@ void listen_lock_status(int server, int *client, sdp_session_t *session) {
 
     GError *error = NULL;
 
-    data_obj.loop = g_main_loop_new(NULL, FALSE);
+    //data_obj.loop = g_main_loop_new(NULL, FALSE);
 
     data_obj.proxy = g_dbus_proxy_new_for_bus_sync(
         G_BUS_TYPE_SESSION,                     //GBus Type
@@ -100,6 +100,6 @@ void listen_lock_status(int server, int *client, sdp_session_t *session) {
     }
 
     data_obj.handler_id = g_signal_connect(data_obj.proxy, "g-signal", G_CALLBACK(on_signal), &data_obj);
-    
-    g_main_loop_run(data_obj.loop);
+    //g_main_iteration(FALSE);
+    //g_main_loop_run(data_obj.loop);
 }


### PR DESCRIPTION
In the previous pull request, #31, I only have tested if the given parameter to `deauth` was a valid , paired, and trusted device. This did not check if the incoming connection was from a trusted device. Therefore, I had to reopen the issue #29 since it did not resolve the issue. I am now checking if the incoming connection satisfies two conditions. 

1. The incoming device is a trusted and paired device
2. The incoming device's Bluetooth address matches the one that has been passed to `deauth`

`deauth` will be given one parameter when executing the program. The parameter is the Bluetooth address that authenticated with PAM. Only the device that authenticates PAM can communicate with the de-authentication server. Hence why I call this device the authorized device.

## Test

### Test 1: Connection from an Unpaired Device
**Setup:**
Check if device is not paired but is trusted:
```
$ bluetoothctl info F0:81:73:92:2E:C2 | grep Connected        
        Connected: no                        
$ grep F0:81:73:92:2E:C2 /etc/proxy_auth/zaku | wc -l
1                                                  
```

**Test:**
```
$ ./deauth 20:DA:22:DE:0F:68                                                                       
Registering UUID 00001101-0000-1000-8000-00805f9b34fb                                                         
accepted connection from F0:81:73:92:2E:C2                                                                                                                                                      
F0:81:73:92:2E:C2 is not trusted or not authorized to deauthenticate the system
```
Since `F0:81:73:92:2E:C2` is not paired with the system, the incoming connection should be rejected.
**[SUCCESS]**

### Test 2: Connecting from an untrusted but paired device
**Setup:**
Check if the device is paired but not trusted:
```
$ grep F0:81:73:92:2E:C2 /etc/proxy_auth/zaku | wc -l
0  
$ bluetoothctl info F0:81:73:92:2E:C2 | grep Connected
        Connected: yes                            
```

**Test:**                                           
```
$ ./deauth 20:DA:22:DE:0F:68                                                                                                                      
Registering UUID 00001101-0000-1000-8000-00805f9b34fb
accepted connection from F0:81:73:92:2E:C2
F0:81:73:92:2E:C2 is not trusted or not authorized to deauthenticate the system
```
Even though the device is paired, since it is not trusted, the system locks as needed
**[SUCCESS]**

### Test 3: Connecting from a trusted and paired device but is not authorized device
**Setup:**
```
$ grep F0:81:73:92:2E:C2 /etc/proxy_auth/zaku | wc -l        
1
$ bluetoothctl info F0:81:73:92:2E:C2 | grep Connected      
        Connected: yes
```

**Test:**
```
$ ./deauth 20:DA:22:DE:0F:68         
Registering UUID 00001101-0000-1000-8000-00805f9b34fb
accepted connection from F0:81:73:92:2E:C2
F0:81:73:92:2E:C2 is not trusted or not authorized to deauthenticate the system
```
Even though the device is both trusted and paired, it is not the device that is authorized to communicate with the deauthentication server. Only `20:DA:22:DE:0F:68` should be communicating with the server since it is the authorized device. Therefore we should expect the system to lock which we did.
**[SUCCESS]**

### Test 4: Connecting from an authorized Device
**Setup:**
Check if the device that is authorized and the device we will be communicating with the server is paired and trusted.
```
$ grep 20:DA:22:DE:0F:68 /etc/proxy_auth/zaku | wc -l         
1                 
$ bluetoothctl info 20:DA:22:DE:0F:68 | grep Connected        
        Connected: yes     
```

**Test:**
Expect: Connection with `20:DA:22:DE:0F:68` is allowed. The system should not lock.
```
$ ./deauth 20:DA:22:DE:0F:68                                                                                    
Registering UUID 00001101-0000-1000-8000-00805f9b34fb                                                         
accepted connection from 20:DA:22:DE:0F:68                                                                    
received [Hello World!]                      
```
As expected, we can communicate with the server on a trusted, paired, and authorized device as needed.
**[SUCCESS]**

---

**NOTE:**
The output has been modified manually to remove the output of connected devices to make the output much clearer. The print statements still remain in the code for debugging purposes.
i.e.
```
$ ./deauth 20:DA:22:DE:0F:68                                 
pika: 20:DA:22:DE:0F:68                                                                                       
pika: F0:81:73:92:2E:C2                                                                                       
pika: 20:DA:22:DE:0F:68
pika: F0:81:73:92:2E:C2
```