### PR TITLE
[#16] Read and Write data to server using a background service

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,10 @@
             android:name=".ControlActivity"
             android:screenOrientation="portrait" />
 
+        <service
+            android:name=".BluetoothInteraction"
+            android:exported="false"/>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="com.domain.fileprovider"

--- a/android/app/src/main/java/com/example/myapplicationtest/BluetoothInteraction.kt
+++ b/android/app/src/main/java/com/example/myapplicationtest/BluetoothInteraction.kt
@@ -1,0 +1,127 @@
+package com.example.myapplicationtest
+
+import android.app.Activity
+import android.app.IntentService
+import android.app.ProgressDialog
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothSocket
+import android.content.Intent
+import android.util.Log
+import android.widget.Toast
+import java.io.IOException
+import java.util.*
+
+class BluetoothInteraction : IntentService("BluetoothInteraction") {
+    companion object {
+        var m_myUUID: UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB")
+        var m_bluetoothSocket: BluetoothSocket? = null
+        lateinit var m__bluetoothAdapter: BluetoothAdapter
+        var m_isConnected: Boolean = false
+        lateinit var m_address: String
+        lateinit var m_name: String
+        private val mmBuffer: ByteArray = ByteArray(1024) // mmBuffer store for the stream
+    }
+
+    override fun onHandleIntent(intent: Intent) {
+        // Gets data from the incoming Intent
+        m_address = intent.getStringExtra(MainActivity.EXTRA_ADDRESS)
+        m_name = intent.getStringExtra(MainActivity.DEVICE_NAME)
+
+        // Do work here, based on the contents of dataString
+        if (!connect()) {
+
+        }
+        runServer()
+    }
+
+    private fun sendCommand(input: String){
+        if (m_bluetoothSocket != null){
+            try{
+                //Log.d("data", "DATA Incoming")
+                Log.d("data", input)
+                m_bluetoothSocket!!.outputStream.write(input.toByteArray())
+            } catch (e: IOException){
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private fun connect() : Boolean {
+        try{
+            if(m_bluetoothSocket == null || !m_isConnected){
+                m__bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+                val device: BluetoothDevice = m__bluetoothAdapter.getRemoteDevice(
+                    m_address
+                )
+                m_bluetoothSocket = device.createInsecureRfcommSocketToServiceRecord(
+                    m_myUUID
+                )
+                //stops the app for looking for other devices
+                BluetoothAdapter.getDefaultAdapter().cancelDiscovery()
+                m_bluetoothSocket!!.connect()
+                Log.i("data", "Successfully Connected")
+                m_isConnected = true
+                return true
+            }
+        }catch (e: IOException){
+            Log.d("data", "Failed to Connect \n")
+            e.printStackTrace()
+        }
+        return false
+    }
+
+    override fun onDestroy() {
+        disconnect()
+    }
+
+    private fun disconnect(){
+        if (m_bluetoothSocket != null) {
+            try {
+                m_isConnected = false
+                m_bluetoothSocket!!.outputStream.close()
+                m_bluetoothSocket!!.inputStream.close()
+                m_bluetoothSocket!!.close()
+            } catch (e: IOException) {
+                e.printStackTrace()
+            } finally { // close the socket
+                m_bluetoothSocket = null
+                Toast.makeText(this, "Disconnecting from Server", Toast.LENGTH_SHORT).show()
+                val intent = Intent(this, MainActivity::class.java)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                this.startActivity(intent)
+            }
+        }
+    }
+
+    private fun runServer() {
+        var buf : String
+
+        while(m_isConnected) {
+            buf = receiveCommand()
+            if (buf.length < 0) {
+                Log.d("data", "Failed to receive data")
+                stopSelf()
+                //break
+            }
+            sendCommand("World")
+        }
+    }
+
+    private fun receiveCommand() : String {
+        var numBytes: Int // bytes returned from read()
+        try {
+            // Keep listening to the InputStream until an exception occurs.
+            // Read from the InputStream.
+            numBytes = m_bluetoothSocket!!.inputStream.read(mmBuffer)
+            Log.d("data", numBytes.toString())
+            Log.d("data", mmBuffer.toString(Charsets.UTF_8))
+            Toast.makeText(this, mmBuffer.toString(Charsets.UTF_8), Toast.LENGTH_LONG)
+            return mmBuffer.toString(Charsets.UTF_8)
+        } catch (e: IOException) {
+            Log.d("data", "Input stream was disconnected", e)
+        }
+        return ""
+    }
+}
+

--- a/android/app/src/main/java/com/example/myapplicationtest/ControlActivity.kt
+++ b/android/app/src/main/java/com/example/myapplicationtest/ControlActivity.kt
@@ -18,18 +18,13 @@ import org.jetbrains.anko.toast
 import java.io.IOException
 import java.util.*
 
-class ControlActivity: AppCompatActivity(){
+class ControlActivity: AppCompatActivity() {
 
-    companion object{
-        var m_myUUID: UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB")
-        var m_bluetoothSocket: BluetoothSocket? = null
-        lateinit var m_progress: ProgressDialog
-        lateinit var m__bluetoothAdapter: BluetoothAdapter
-        var m_isConnected: Boolean = false
+    companion object {
         lateinit var m_address: String
         lateinit var m_name: String
-        private val mmBuffer: ByteArray = ByteArray(1024) // mmBuffer store for the stream
     }
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,117 +39,16 @@ class ControlActivity: AppCompatActivity(){
         deviceAddress.text = cDeviceAddr
 
         // connecting to the device
-        ConnectToDevice(this).execute()
+        val intent = Intent(this, BluetoothInteraction::class.java)
+        intent.putExtra(MainActivity.EXTRA_ADDRESS, m_address)
+        intent.putExtra(MainActivity.DEVICE_NAME, m_name)
+        intent.also { intent ->
+            startService(intent)
+        }
 
-        test_button.setOnClickListener{ sendCommand("Hello World!")} //for now sending this
-        control_led_disconnect.setOnClickListener{ disconnect()}
+        disconnect.setOnClickListener { stopService(intent) }
     }
 
-    private fun sendCommand(input: String){
-        if (m_bluetoothSocket != null){
-            try{
-                //Log.d("data", "DATA Incoming")
-                Log.d("data", input)
-                m_bluetoothSocket!!.outputStream.write(input.toByteArray())
-            } catch (e: IOException){
-                e.printStackTrace()
-            }
-        }
-        receiveCommand()
-    }
-
-    private fun receiveCommand(){
-        var numBytes: Int // bytes returned from read()
-        try {
-            // Keep listening to the InputStream until an exception occurs.
-            while (true) {
-                // Read from the InputStream.
-                //numBytes =
-                try {
-                    numBytes = m_bluetoothSocket!!.inputStream.read(mmBuffer)
-                    Log.d("data", numBytes.toString())
-                    Log.d("data", mmBuffer.toString(Charsets.UTF_8))
-                    toast(mmBuffer.toString(Charsets.UTF_8))
-                } catch (e: IOException) {
-                    Log.d("data", "Input stream was disconnected", e)
-                    break
-                }
-                // we have the data from the computer in the buffer mmBuffer now, turn it into text here
-                toast("data received")
-                Log.d("data", mmBuffer.toString(Charsets.UTF_8))
-            }
-
-        } catch (e: Exception){
-            toast("Failed to read")
-        }
-    }
-
-    private fun disconnect(){
-        if (m_bluetoothSocket != null){
-            try {
-                m_isConnected = false
-                m_bluetoothSocket!!.outputStream.close()
-                m_bluetoothSocket!!.inputStream.close()
-                m_bluetoothSocket!!.close()
-            } catch (e: IOException){
-                e.printStackTrace()
-            } finally { // close the socket
-                m_bluetoothSocket = null
-                toast("Disconnecting from Server")
-                //m_isConnected = false
-                val intent = Intent(this, MainActivity::class.java)
-                startActivity(intent)
-            }
-        }
-        finish()
-    }
-
-    private class ConnectToDevice(c: Context): AsyncTask<Void, Void, String>(){
-
-        private var connectSuccess: Boolean = true
-        private val context: Context
-
-        init {
-            this.context = c
-        }
-
-        override fun onPreExecute(){
-            super.onPreExecute()
-            m_progress = ProgressDialog.show(context, "Connecting...", "Please Wait")
-        }
-
-        override fun doInBackground(vararg p0: Void?): String?{
-            try{
-                if(m_bluetoothSocket == null || !m_isConnected){
-                    m__bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
-                    val device: BluetoothDevice = m__bluetoothAdapter.getRemoteDevice(m_address)
-                    m_bluetoothSocket = device.createInsecureRfcommSocketToServiceRecord(m_myUUID)
-                    //stops the app for looking for other devices
-                    BluetoothAdapter.getDefaultAdapter().cancelDiscovery()
-                    m_bluetoothSocket!!.connect()
-                }
-            }catch (e: IOException){
-                connectSuccess =  false
-                Log.d("data", "Failed to Connect \n")
-                e.printStackTrace()
-            }
-            return null
-        }
-
-        override fun onPostExecute(result: String?){
-            super.onPostExecute(result)
-            if(!connectSuccess){
-                Log.i("data", "Unable to Connect")
-                val intent = Intent(this.context, MainActivity::class.java)
-                this.context.toast("Failed to Connect to " + m_address)
-                this.context.startActivity(intent)
-            } else {
-                Log.i("data", "Successfully Connected")
-                m_isConnected = true
-            }
-            m_progress.dismiss()
-        }
-    }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         val inflater: MenuInflater = menuInflater
@@ -206,11 +100,4 @@ class ControlActivity: AppCompatActivity(){
 
 
     }
-
 }
-
-
-// for disconnet(), if needed
-/** finally {
-    m_bluetoothSocket!!.close()
-} */

--- a/android/app/src/main/res/layout/control_layout.xml
+++ b/android/app/src/main/res/layout/control_layout.xml
@@ -30,32 +30,18 @@
         app:layout_constraintTop_toBottomOf="@+id/connectedDevice" />
 
     <Button
-        android:id="@+id/test_button"
+        android:id="@+id/disconnect"
         style="@style/Widget.AppCompat.Button.Colored"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="144dp"
-        android:fontFamily="@font/acme"
-        android:text="@string/helloWorld"
-        android:textSize="18sp"
-        app:layout_constraintHorizontal_bias="0.498"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/deviceAddress" />
-
-    <Button
-        android:id="@+id/control_led_disconnect"
-        style="@style/Widget.AppCompat.Button.Colored"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="44dp"
+        android:layout_marginTop="50dp"
         android:fontFamily="@font/acme"
         android:text="@string/disconnect"
         android:textSize="18sp"
         app:layout_constraintHorizontal_bias="0.498"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/test_button" />
+        app:layout_constraintTop_toBottomOf="@+id/deviceAddress" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/pam/src/deauth.c
+++ b/pam/src/deauth.c
@@ -404,6 +404,8 @@ int main (int argc, char **argv)
     	if (bytes_read > 0 && write(client, buf, strlen(buf) < 0)) {
     	    perror("Error writing to client");	
     	}
+        char *msg = "hello";
+        write(client, msg, strlen(msg));
         check_lock_status(data_obj->context);
     }
     //should never come here unless the program is killed or the loop breaks

--- a/pam/src/proxy_dbus.h
+++ b/pam/src/proxy_dbus.h
@@ -129,7 +129,6 @@ struct dbus_obj *set_lock_listener(struct server_data_t *server) {
 }
 
 void check_lock_status(GMainContext *context) {
-    printf("check status\n");
     for (int i = 0; i < 15; i++) {
         g_main_context_iteration(context, FALSE);
     }


### PR DESCRIPTION
## Review Deadline: Thursday April 3 at 6pm before I merge it to master

As I mentioned in #16, I [commentted](https://github.com/zakuArbor/proxyAuth/issues/16#issuecomment-607080328) how the current implementation is incorrect because the app will not read from the server till it send a message to the server. In addition, after sending one message, it'll just constantly read from the server only. We also need to write back to the server which I know @bistanur initially implemented in the beginning with a button to send a message back to the server. A good start to work on read and write to the server but now that we are in the last stage of the sprint, we should be reading and writing consecutively. I know @ArslanAhmedQ was working on the issue #16 to make it work as a background service and placed the issue to testing phase. However, since this issue has been stuck for a while, I decided to take over.

I wish for the Android team to review my changes and know what changes I have made in case there are anything wrong with my implementation.

# Runtime
To test whether or not messages are being continually read and written to both the Android and de-authentication server, I have made the app write "World" and the server to write "Hello" to the app. Here's the following output for each application when I connected them together:

**Android Sample Output under Android run console:**
I have truncated a lot of `�` characters. I'll have to investigate when this is.
```
D/data: 5
    hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohello
D/data: World
D/data: 5
    hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohello
D/data: World
D/data: 10
    hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohello
D/data: World
D/data: 5
```

**In the server's side:**
```
$ /etc/proxy_auth/deauth 20:DA:22:DE:0F:68
pika: 20:DA:22:DE:0F:68
Registering UUID 00001101-0000-1000-8000-00805f9b34fb
accepted connection from 20:DA:22:DE:0F:68
pika: 20:DA:22:DE:0F:68
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
received [World]
```

# Disconnect
On the Android side, I can still disconnect from the server which will kill the service. However, there still needs to be more work done to fix the issue when the server closes before the client. I believe this is a minor bug that can be easily addressed.