### PR TITLE
[#69] Fix regex to match OS Attempt

### DIFF
--- a/pam/Makefile
+++ b/pam/Makefile
@@ -4,7 +4,7 @@ PFLAGS += -fPIC -fno-stack-protector
 LDFLAGS = -x --shared
 GLIB = `pkg-config --libs glib-2.0 gio-2.0`
 G_CFLAGS = `pkg-config --cflags glib-2.0 gio-2.0`
-OS:=$(shell grep -E "^ID" /etc/os-release | cut -d = -f 2)
+OS:=$(shell grep -E "^ID=" /etc/os-release | cut -d = -f 2)
 DEAUTH_PATH = /etc/proxy_auth
 
 ifeq ($(OS), fedora)

--- a/pam/install.pl
+++ b/pam/install.pl
@@ -104,7 +104,7 @@ If invalid OS, will return an empty string
 sub get_distro {
 	my $os="";
 	if (-e '/etc/os-release') {
-		$os=`grep -E "^ID" /etc/os-release | grep ID | cut -d = -f 2`;
+		$os=`grep -E "^ID=" /etc/os-release | grep ID | cut -d = -f 2`;
     chomp($os);
     $os =~ s/"//g;
 	}


### PR DESCRIPTION
*closes #69*

Update regex pattern in `Makefile` and `install.pl` to be more strict.

**Tested Platforms:** Fedora and Ubuntu