### PR TITLE
[#71 - pam_bt_trust] Check bounds in get_trusted_dev_file

### DIFF
--- a/pam/src/pam_bt_trust.c
+++ b/pam/src/pam_bt_trust.c
@@ -26,31 +26,33 @@ int find_trusted_paired_device(FILE *log_fp, char **trusted_devices, int num_of_
 FILE *get_trusted_dev_file(const char *trusted_dir_path, const char *username, FILE *log_fp) {
     FILE *trusted_dev_fp = NULL;
 
-    char file_name[NAME_MAX];
-    int len = 0, copy_len = 0;
+    const unsigned int buf_size = PATH_MAX + LOGIN_NAME_MAX;
+    char file_name[buf_size]; //assumes LOGIN_NAME_MAX <= NAME_MAX
+    unsigned int len = 0, copy_len = 0;
     strcpy(file_name, "");
     
     if (strlen(trusted_dir_path) > 0) {
         copy_len = strlen(trusted_dir_path);
-        copy_len = copy_len > NAME_MAX ? NAME_MAX : copy_len;
+        copy_len = copy_len > (PATH_MAX -1) ? (PATH_MAX - 1): copy_len; //PATH_MAX includes null-terminator
         strncat(file_name, trusted_dir_path, copy_len); 
         len += copy_len;
     }
+
     if (strlen(username) > 0) {
         copy_len = strlen(username);
-        copy_len = (copy_len > NAME_MAX - len) ? (NAME_MAX - len) : copy_len;
+        copy_len = (copy_len > LOGIN_NAME_MAX) ? LOGIN_NAME_MAX : copy_len;
         strncat(file_name, username, copy_len);
         len += copy_len;
     }
     //I am paranoid
-    if (len > NAME_MAX) {
-        file_name[NAME_MAX-1] = '\0';
+    if (len > buf_size) {
+        file_name[buf_size-1] = '\0';
     }
     else {
         file_name[len] = '\0';
     }
 
-    assert(strlen(file_name) < NAME_MAX);
+    assert(strlen(file_name) < buf_size);
 
     if (!(check_config(log_fp, file_name, 0))) {
         return NULL;

--- a/pam/src/pam_bt_trust.c
+++ b/pam/src/pam_bt_trust.c
@@ -28,15 +28,18 @@ FILE *get_trusted_dev_file(const char *trusted_dir_path, const char *username, F
 
     const unsigned int buf_size = PATH_MAX + LOGIN_NAME_MAX;
     char file_name[buf_size]; //assumes LOGIN_NAME_MAX <= NAME_MAX
-    unsigned int len = 0, copy_len = 0;
+    unsigned int copy_len = 0;
+    unsigned int len = 0;
     strcpy(file_name, "");
     
     if (strlen(trusted_dir_path) > 0) {
         copy_len = strlen(trusted_dir_path);
         copy_len = copy_len > (PATH_MAX -1) ? (PATH_MAX - 1): copy_len; //PATH_MAX includes null-terminator
         strncat(file_name, trusted_dir_path, copy_len); 
-        len += copy_len;
+        len = copy_len;
     }
+
+    assert(strlen(file_name) < buf_size);
 
     if (strlen(username) > 0) {
         copy_len = strlen(username);
@@ -44,6 +47,9 @@ FILE *get_trusted_dev_file(const char *trusted_dir_path, const char *username, F
         strncat(file_name, username, copy_len);
         len += copy_len;
     }
+
+    assert(strlen(file_name) < buf_size);
+    
     //I am paranoid
     if (len > buf_size) {
         file_name[buf_size-1] = '\0';
@@ -51,8 +57,6 @@ FILE *get_trusted_dev_file(const char *trusted_dir_path, const char *username, F
     else {
         file_name[len] = '\0';
     }
-
-    assert(strlen(file_name) < buf_size);
 
     if (!(check_config(log_fp, file_name, 0))) {
         return NULL;

--- a/pam/src/pam_bt_trust.c
+++ b/pam/src/pam_bt_trust.c
@@ -27,24 +27,30 @@ FILE *get_trusted_dev_file(const char *trusted_dir_path, const char *username, F
     FILE *trusted_dev_fp = NULL;
 
     char file_name[NAME_MAX];
-    int len = 0;
+    int len = 0, copy_len = 0;
     strcpy(file_name, "");
     
     if (strlen(trusted_dir_path) > 0) {
-        strncat(file_name, trusted_dir_path, strlen(trusted_dir_path));
-        len += strlen(trusted_dir_path);
+        copy_len = strlen(trusted_dir_path);
+        copy_len = copy_len > NAME_MAX ? NAME_MAX : copy_len;
+        strncat(file_name, trusted_dir_path, copy_len); 
+        len += copy_len;
     }
     if (strlen(username) > 0) {
-        strncat(file_name, username, strlen(username));
-        len += strlen(username);
+        copy_len = strlen(username);
+        copy_len = (copy_len > NAME_MAX - len) ? (NAME_MAX - len) : copy_len;
+        strncat(file_name, username, copy_len);
+        len += copy_len;
     }
     //I am paranoid
     if (len > NAME_MAX) {
-        file_name[NAME_MAX] = '\0';
+        file_name[NAME_MAX-1] = '\0';
     }
     else {
         file_name[len] = '\0';
     }
+
+    assert(strlen(file_name) < NAME_MAX);
 
     if (!(check_config(log_fp, file_name, 0))) {
         return NULL;

--- a/pam/src/pam_bt_trust.h
+++ b/pam/src/pam_bt_trust.h
@@ -1,6 +1,7 @@
 #ifndef PAM_BT_TRUST
 #define PAM_BT_TRUST
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include "pam_misc.h"

--- a/pam/src/pam_sec.h
+++ b/pam/src/pam_sec.h
@@ -1,4 +1,4 @@
-/*
+/**
 * @author: zakuarbor (Ju Hong Kim)
 * @brief: Where security checks and security tools are placed
 */
@@ -15,7 +15,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-/*
+/**
 * Return 1 iff the file exists (and not a link) and has the correct permission
 * 
 * @param log_fp: the handle of the log file
@@ -25,7 +25,7 @@
 */
 int check_config(FILE *log_fp, const char * const file, const int is_dir);
 
-/*
+/**
 * Return 1 iff the file exists and is not a symlink. Else returns a 0.
 *
 * @param log_fp: the handle of the log file
@@ -35,7 +35,7 @@ int check_config(FILE *log_fp, const char * const file, const int is_dir);
 */
 int is_nlnk(FILE *log_fp, const char * const file, struct stat * const st);
 
-/*
+/**
 * Return 1 iff the file is owned by root and has rw permission and the other fields does not have write permission
 *
 * @param log_fp: the handle of the log file


### PR DESCRIPTION
Closes #71 

**Changes:**
* increase buffersize of the file name to include `PATH_MAX` and `LOGIN_MAX_NAME`
* copy the min between the string and it's corresponding max size macro
* ensure I do not write a null character past the buffer if the length of the string exceeds the buf size (should never get there though)

**Test;**
* Tested a directory with over 4096 characters length
* Tested with a filename over 255 characters in length