### PR TITLE
[59] Set heap var. to NULL after free

### DIFF
--- a/pam/src/pam_bt_misc.c
+++ b/pam/src/pam_bt_misc.c
@@ -56,7 +56,9 @@ void free_device_list(char **device_list, int num_of_devices) {
     if (device_list) {
         for (int i = 0; i < num_of_devices; i++) {
             free(device_list[i]);
+            device_list[i] = NULL;
         }
-        free(device_list);
+        free(device_list); 
+        device_list = NULL;
     }
 }

--- a/pam/src/pam_proxy.c
+++ b/pam/src/pam_proxy.c
@@ -38,9 +38,7 @@ PAM_EXTERN int pam_sm_authenticate( pam_handle_t *pamh, int flags,int argc, cons
             fprintf(log_fp, "Login via Auth Proxy\n");
         }
         exec_deauth(detected_dev, username, log_fp, trusted_dir_path);
-        if (detected_dev) {
-            free(detected_dev);
-        }
+        free(detected_dev);
         bluetooth_status = PAM_SUCCESS;
     }
 


### PR DESCRIPTION
To avoid double free, set heap variable to NULL. According to manpages, 'If ptr is NULL, no operation is performed.' so it is safe to not check if variable is NULL before free